### PR TITLE
Fix PMTiles map loading on production

### DIFF
--- a/assets/js/deeplink-handler.js
+++ b/assets/js/deeplink-handler.js
@@ -56,7 +56,7 @@
             
             // Update iOS Smart App Banner
             if (this.uid) {
-                const appArgument = `iburn://${this.type}/${this.uid}`;
+                const appArgument = `iburn://${this.type}?uid=${this.uid}`;
                 document.getElementById('ios-app-banner').content = 
                     `app-id=388169740, app-argument=${appArgument}`;
             }
@@ -69,8 +69,8 @@
                 // Pin uses query parameters
                 deepLink += `pin?${this.params.toString()}`;
             } else if (this.uid) {
-                // Build path with UID
-                deepLink += `${this.type}/${this.uid}`;
+                // Build URL with UID as parameter
+                deepLink += `${this.type}?uid=${this.uid}`;
                 // Add other parameters (excluding uid/id)
                 const otherParams = new URLSearchParams();
                 for (const [key, value] of this.params.entries()) {
@@ -79,7 +79,7 @@
                     }
                 }
                 if (otherParams.toString()) {
-                    deepLink += `?${otherParams.toString()}`;
+                    deepLink += `&${otherParams.toString()}`;
                 }
             }
             

--- a/assets/js/map-viewer.js
+++ b/assets/js/map-viewer.js
@@ -21,6 +21,13 @@ class MapViewer {
             const styleResponse = await fetch(styleUrl);
             const style = await styleResponse.json();
             
+            // Fix PMTiles URL for production environment
+            const isLocalDev = location.host.includes('localhost') || location.host.includes('127.0.0.1');
+            if (!isLocalDev && style.sources.composite && style.sources.composite.url.startsWith('pmtiles:///')) {
+                const relativePath = style.sources.composite.url.replace('pmtiles:///', '/');
+                style.sources.composite.url = `pmtiles://${location.protocol}//${location.host}${relativePath}`;
+            }
+            
             // Remove sprite reference since we'll load images directly
             delete style.sprite;
             

--- a/test-deeplink.html
+++ b/test-deeplink.html
@@ -32,8 +32,8 @@
     
     <h2>Direct Deep Links (for testing)</h2>
     <ul>
-        <li><a href="iburn://art/a1XVI000008yf262AA">Direct iburn:// art link</a></li>
-        <li><a href="iburn://camp/a1XVI000008zNKs2AM">Direct iburn:// camp link</a></li>
+        <li><a href="iburn://art?uid=a1XVI000008yf262AA">Direct iburn:// art link</a></li>
+        <li><a href="iburn://camp?uid=a1XVI000008zNKs2AM">Direct iburn:// camp link</a></li>
         <li><a href="iburn://pin?lat=40.7868&lng=-119.2068&title=Test%20Pin">Direct iburn:// pin link</a></li>
     </ul>
 </body>


### PR DESCRIPTION
## Summary
- Fix PMTiles map loading issue on production (iburnapp.com) by converting relative URLs to absolute URLs
- Maintain compatibility with local development environment
- Fix deeplink URL format to use query parameters instead of path parameters

## Changes
- Add environment detection to distinguish between local development and production
- Convert PMTiles URLs from relative format (`pmtiles:///data/...`) to absolute format (`pmtiles://https://iburnapp.com/data/...`) when not running locally
- Update deeplink URL construction to use query parameters for better compatibility

## Issue Fixed
Resolves the "TypeError: Extra bytes past the end" error that was occurring with PMTiles on production due to range request handling issues.

🤖 Generated with [Claude Code](https://claude.ai/code)